### PR TITLE
feat: ダッシュボードのUI全面改修と機能実装

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,17 +4,39 @@ from fastapi.staticfiles import StaticFiles
 import json
 from datetime import datetime
 import os
+import re
 
 app = FastAPI()
 
 DATA_DIR = 'data'
 
 def get_latest_data_file():
-    """Finds the latest data_YYYY-MM-DD.json file."""
-    # For this implementation, we'll use a fixed name for simplicity,
-    # as specified in the data_fetcher.py placeholder.
-    # A real implementation would dynamically find the latest file based on date.
-    return os.path.join(DATA_DIR, 'data.json')
+    """
+    Finds the latest data_YYYY-MM-DD.json file in the DATA_DIR.
+    """
+    if not os.path.isdir(DATA_DIR):
+        return None
+
+    files = os.listdir(DATA_DIR)
+    data_files = []
+    # Regex to match the dated file format
+    file_pattern = re.compile(r'^data_(\d{4}-\d{2}-\d{2})\.json$')
+
+    for f in files:
+        match = file_pattern.match(f)
+        if match:
+            data_files.append(f)
+
+    if not data_files:
+        # Fallback to data.json if no dated files are found
+        fallback_path = os.path.join(DATA_DIR, 'data.json')
+        if os.path.exists(fallback_path):
+            return fallback_path
+        return None
+
+    # Sort files by date (newest first) and return the latest one
+    latest_file = sorted(data_files, reverse=True)[0]
+    return os.path.join(DATA_DIR, latest_file)
 
 @app.get("/api/health")
 def health_check():

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,229 +1,306 @@
 document.addEventListener('DOMContentLoaded', () => {
     console.log("HanaView Dashboard Initialized");
 
-    // Register Service Worker
+    // --- Service Worker Registration ---
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
             navigator.serviceWorker.register('/sw.js')
-                .then(registration => {
-                    console.log('Service Worker registered: ', registration);
-                })
-                .catch(registrationError => {
-                    console.log('Service Worker registration failed: ', registrationError);
-                });
+                .then(reg => console.log('Service Worker registered.', reg))
+                .catch(err => console.log('Service Worker registration failed: ', err));
         });
     }
 
-    const dashboardElement = document.getElementById('dashboard');
+    // --- Tab-switching logic ---
+    function initTabs() {
+        const tabContainer = document.querySelector('.tab-container');
+        tabContainer.addEventListener('click', (e) => {
+            if (!e.target.matches('.tab-button')) return;
+
+            const targetTab = e.target.dataset.tab;
+
+            document.querySelectorAll('.tab-button').forEach(button => {
+                button.classList.toggle('active', button.dataset.tab === targetTab);
+            });
+            document.querySelectorAll('.tab-pane').forEach(pane => {
+                pane.classList.toggle('active', pane.id === `${targetTab}-content`);
+            });
+        });
+    }
+
+    // --- Rendering Functions ---
+
+    function renderMarketOverview(container, marketData) {
+        if (!container) return;
+        container.innerHTML = ''; // Clear content
+
+        const card = document.createElement('div');
+        card.className = 'card';
+
+        let content = '';
+
+        // Fear & Greed Index
+        const fgData = marketData.fear_and_greed;
+        if (fgData && fgData.now !== null) {
+            const rotation = (fgData.now / 100) * 180 - 90;
+            content += `
+                <div class="market-section">
+                    <h3>Fear & Greed Index</h3>
+                    <div class="fg-container">
+                        <div class="fg-gauge">
+                            <div class="fg-gauge-base"></div>
+                            <div class="fg-gauge-needle" style="transform: rotate(${rotation}deg);"></div>
+                            <div class="fg-gauge-center"></div>
+                        </div>
+                        <div class="fg-value-display">
+                            <div class="fg-now-value">${fgData.now}</div>
+                            <div class="fg-now-category">${fgData.category}</div>
+                        </div>
+                    </div>
+                    <div class="fg-history">
+                        <p><strong>Previous Close:</strong> ${fgData.previous_close || 'N/A'}</p>
+                        <p><strong>1 Week Ago:</strong> ${fgData.prev_week || 'N/A'}</p>
+                        <p><strong>1 Month Ago:</strong> ${fgData.prev_month || 'N/A'}</p>
+                        <p><strong>1 Year Ago:</strong> ${fgData.prev_year || 'N/A'}</p>
+                    </div>
+                </div>
+            `;
+        }
+
+        // AI Commentary
+        if (marketData.ai_commentary) {
+            content += `
+                <div class="market-section">
+                    <h3>AI市況解説</h3>
+                    <p>${marketData.ai_commentary}</p>
+                </div>
+            `;
+        }
+
+        // TradingView Charts
+        content += `
+            <div class="market-grid">
+                <div class="market-section">
+                    <h3>VIX指数 (4時間足)</h3>
+                    <div class="tradingview-widget-container" style="height:400px; width:100%;">
+                        <div id="tradingview-vix"></div>
+                    </div>
+                </div>
+                <div class="market-section">
+                    <h3>米国10年債先物 (4時間足)</h3>
+                    <div class="tradingview-widget-container" style="height:400px; width:100%;">
+                        <div id="tradingview-t-note"></div>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        card.innerHTML = content;
+        container.appendChild(card);
+
+        // --- Embed TradingView Widgets ---
+        // This requires the TradingView script to be loaded in index.html
+        // The script is added to index.html in the next step.
+        // For now, we define the creation logic.
+        if (typeof TradingView !== 'undefined') {
+            // VIX Chart
+            new TradingView.widget({
+                "autosize": true,
+                "symbol": "TVC:VIX",
+                "interval": "240",
+                "timezone": "Asia/Tokyo",
+                "theme": "light",
+                "style": "1",
+                "locale": "ja",
+                "enable_publishing": false,
+                "hide_side_toolbar": false,
+                "allow_symbol_change": true,
+                "container_id": "tradingview-vix"
+            });
+
+            // T-Note Chart
+            new TradingView.widget({
+                "autosize": true,
+                "symbol": "ZN1!",
+                "interval": "240",
+                "timezone": "Asia/Tokyo",
+                "theme": "light",
+                "style": "1",
+                "locale": "ja",
+                "enable_publishing": false,
+                "hide_side_toolbar": false,
+                "allow_symbol_change": true,
+                "container_id": "tradingview-t-note"
+            });
+        }
+    }
 
     function renderNews(container, newsData) {
-        if (!newsData || (!newsData.summary && !newsData.topics)) {
-            container.innerHTML += '<h2>News</h2><p>No news data available.</p>';
+        if (!container) return;
+        container.innerHTML = '';
+        if (!newsData || (!newsData.summary && (!newsData.topics || newsData.topics.length === 0))) {
+            container.innerHTML = '<div class="card"><p>ニュースデータがありません。</p></div>';
             return;
         }
-
-        const newsContainer = document.createElement('div');
-        newsContainer.className = 'news-container';
-
-        // --- 3-line summary ---
+        const card = document.createElement('div');
+        card.className = 'card';
         if (newsData.summary) {
-            const summaryDiv = document.createElement('div');
-            summaryDiv.className = 'news-summary';
-            const summaryTitle = document.createElement('h3');
-            summaryTitle.textContent = '今朝の3行サマリー';
-            summaryDiv.appendChild(summaryTitle);
-            const summaryText = document.createElement('p');
-            summaryText.textContent = newsData.summary;
-            summaryDiv.appendChild(summaryText);
-            newsContainer.appendChild(summaryDiv);
+            card.innerHTML += `<div class="news-summary"><h3>今朝の3行サマリー</h3><p>${newsData.summary.replace(/\n/g, '<br>')}</p></div>`;
         }
-
-        // --- Main Topics ---
         if (newsData.topics && newsData.topics.length > 0) {
             const topicsContainer = document.createElement('div');
             topicsContainer.className = 'main-topics-container';
-            const topicsTitle = document.createElement('h3');
-            topicsTitle.textContent = '主要トピック';
-            topicsContainer.appendChild(topicsTitle);
-
+            topicsContainer.innerHTML = '<h3>主要トピック</h3>';
             newsData.topics.forEach((topic, index) => {
-                const topicBox = document.createElement('div');
-                topicBox.className = 'topic-box';
-
-                const topicTitle = document.createElement('p');
-                topicTitle.className = 'topic-title';
-
-                // Coloring titles based on index
-                if (index === 0) {
-                    topicTitle.classList.add('topic-title-red');
-                } else {
-                    topicTitle.classList.add('topic-title-blue');
-                }
-                topicTitle.textContent = `${index + 1}. ${topic.title}`;
-
-                const topicBody = document.createElement('p');
-                topicBody.textContent = topic.body;
-
-                topicBox.appendChild(topicTitle);
-                topicBox.appendChild(topicBody);
-                topicsContainer.appendChild(topicBox);
+                topicsContainer.innerHTML += `
+                    <div class="topic-box">
+                        <p class="topic-title ${index === 0 ? 'topic-title-red' : 'topic-title-blue'}">${index + 1}. ${topic.title}</p>
+                        <p>${topic.body}</p>
+                    </div>`;
             });
-            newsContainer.appendChild(topicsContainer);
+            card.appendChild(topicsContainer);
         }
-
-        container.appendChild(newsContainer);
+        container.appendChild(card);
     }
 
     function getPerformanceColor(performance) {
-        // Finviz風の色分け
-        if (performance >= 3) return '#00c853';    // Strong Green
-        if (performance > 1) return '#2e7d32';     // Medium Green
-        if (performance > 0) return '#66bb6a';     // Light Green
-        if (performance == 0) return '#888888';    // Neutral Gray
-        if (performance > -1) return '#ef5350';    // Light Red
-        if (performance > -3) return '#e53935';    // Medium Red
-        return '#c62828';                          // Strong Red
+        if (performance >= 3) return '#00c853';
+        if (performance > 1) return '#2e7d32';
+        if (performance > 0) return '#66bb6a';
+        if (performance == 0) return '#888888';
+        if (performance > -1) return '#ef5350';
+        if (performance > -3) return '#e53935';
+        return '#c62828';
     }
 
     function renderHeatmap(container, title, heatmapData) {
+        if (!container) return;
+        container.innerHTML = '';
         if (!heatmapData || !heatmapData.stocks || heatmapData.stocks.length === 0) {
-            container.innerHTML += `<div class="heatmap-error">No data for ${title}.</div>`;
+            container.innerHTML = `<div class="card"><div class="heatmap-error">No data for ${title}.</div></div>`;
+            return;
+        }
+        const card = document.createElement('div');
+        card.className = 'card';
+        const heatmapWrapper = document.createElement('div');
+        heatmapWrapper.className = 'heatmap-wrapper';
+        heatmapWrapper.innerHTML = `<h2 class="heatmap-main-title">${title}</h2>`;
+        const width = 1000, height = 600;
+        const svg = d3.create("svg").attr("viewBox", `0 0 ${width} ${height}`).attr("width", "100%").attr("height", "auto").style("font-family", "sans-serif");
+        const root = d3.hierarchy(d3.group(heatmapData.stocks, d => d.sector, d => d.industry)).sum(d => (d && d.market_cap) ? d.market_cap : 0).sort((a, b) => b.value - a.value);
+        d3.treemap().size([width, height]).paddingTop(28).paddingInner(3).round(true)(root);
+        const tooltip = d3.select("body").append("div").attr("class", "heatmap-tooltip").style("opacity", 0);
+        const node = svg.selectAll("g").data(root.descendants()).join("g").attr("transform", d => `translate(${d.x0},${d.y0})`);
+        node.filter(d => d.depth === 1 || d.depth === 2).append("text").attr("class", d => d.depth === 1 ? "sector-label" : "industry-label").attr("x", 4).attr("y", 20).text(d => d.data[0]);
+        const leaf = node.filter(d => d.depth === 3);
+        leaf.append("rect").attr("class", "stock-rect").attr("fill", d => getPerformanceColor(d.data.performance)).attr("width", d => d.x1 - d.x0).attr("height", d => d.y1 - d.y0)
+            .on("mouseover", (event, d) => {
+                tooltip.transition().duration(200).style("opacity", .9);
+                tooltip.html(`<strong>${d.data.ticker}</strong><br/>${d.data.industry}<br/>Perf: ${d.data.performance.toFixed(2)}%<br/>Mkt Cap: ${(d.data.market_cap / 1e9).toFixed(2)}B`).style("left", (event.pageX + 5) + "px").style("top", (event.pageY - 28) + "px");
+            }).on("mouseout", () => tooltip.transition().duration(500).style("opacity", 0));
+        leaf.append("clipPath").attr("id", d => `clip-${d.data.ticker}`).append("rect").attr("width", d => d.x1 - d.x0).attr("height", d => d.y1 - d.y0);
+        leaf.append("text").attr("class", "stock-label").attr("clip-path", d => `url(#clip-${d.data.ticker})`).selectAll("tspan").data(d => [d.data.ticker, `${d.data.performance.toFixed(2)}%`]).join("tspan").attr("x", 4).attr("y", (d, i) => i === 0 ? "1.1em" : "2.2em").text(d => d);
+        heatmapWrapper.appendChild(svg.node());
+        card.appendChild(heatmapWrapper);
+        container.appendChild(card);
+    }
+
+    function renderIndicators(container, indicatorsData) {
+        if (!container) return;
+        container.innerHTML = '';
+        if (!indicatorsData || !indicatorsData.economic || indicatorsData.economic.length === 0) {
+            container.innerHTML = '<div class="card"><p>表示する経済指標はありません。</p></div>';
             return;
         }
 
-        const heatmapWrapper = document.createElement('div');
-        heatmapWrapper.className = 'heatmap-wrapper';
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = '<h3>経済指標カレンダー</h3>';
 
-        const headerTitle = document.createElement('h2');
-        headerTitle.className = 'heatmap-main-title';
-        headerTitle.textContent = title;
-        heatmapWrapper.appendChild(headerTitle);
+        const table = document.createElement('table');
+        table.className = 'indicators-table';
 
-        // --- D3 Treemap Implementation ---
-        const width = 1000;
-        const height = 600;
-        const svg = d3.create("svg")
-            .attr("viewBox", `0 0 ${width} ${height}`)
-            .attr("width", "100%")
-            .attr("height", "auto")
-            .style("font-family", "sans-serif");
+        table.innerHTML = `
+            <thead>
+                <tr>
+                    <th>時刻</th>
+                    <th>国</th>
+                    <th>指標名</th>
+                    <th>重要度</th>
+                    <th>予測</th>
+                    <th>結果</th>
+                </tr>
+            </thead>
+        `;
 
-        // 1. Create hierarchy
-        const groupedData = d3.group(heatmapData.stocks, d => d.sector, d => d.industry);
-        const root = d3.hierarchy(groupedData)
-            .sum(d => (d.market_cap && d.ticker) ? d.market_cap : 0) // Sum market_cap for leaf nodes
-            .sort((a, b) => b.value - a.value);
+        const tbody = document.createElement('tbody');
+        indicatorsData.economic.forEach(ind => {
+            const row = document.createElement('tr');
+            const importanceStars = '★'.repeat(ind.importance || 0).padEnd(3, '☆');
+            row.innerHTML = `
+                <td>${ind.time || '--'}</td>
+                <td>${ind.country || '--'}</td>
+                <td>${ind.name || '--'}</td>
+                <td class="importance-${ind.importance || 0}">${importanceStars}</td>
+                <td>${ind.forecast || '--'}</td>
+                <td>${ind.result || '--'}</td>
+            `;
+            tbody.appendChild(row);
+        });
 
-        // 2. Create treemap layout
-        const treemap = d3.treemap()
-            .size([width, height])
-            .paddingTop(28)
-            .paddingInner(3)
-            .round(true);
-
-        treemap(root);
-
-        // Tooltip
-        const tooltip = d3.select("body").append("div")
-            .attr("class", "heatmap-tooltip")
-            .style("opacity", 0);
-
-        // 3. Draw the cells
-        const node = svg.selectAll("g")
-            .data(root.descendants())
-            .join("g")
-            .attr("transform", d => `translate(${d.x0},${d.y0})`);
-
-        // Sector and Industry Headers
-        node.filter(d => d.depth === 1 || d.depth === 2)
-            .append("text")
-            .attr("class", d => d.depth === 1 ? "sector-label" : "industry-label")
-            .attr("x", 4)
-            .attr("y", 20)
-            .text(d => d.data[0]);
-
-        // Stock Tiles
-        const leaf = node.filter(d => d.depth === 3);
-
-        leaf.append("rect")
-            .attr("class", "stock-rect")
-            .attr("fill", d => getPerformanceColor(d.data.performance))
-            .attr("width", d => d.x1 - d.x0)
-            .attr("height", d => d.y1 - d.y0)
-            .on("mouseover", (event, d) => {
-                tooltip.transition().duration(200).style("opacity", .9);
-                tooltip.html(`<strong>${d.data.ticker}</strong><br/>${d.data.industry}<br/>Perf: ${d.data.performance.toFixed(2)}%<br/>Mkt Cap: ${(d.data.market_cap / 1e9).toFixed(2)}B`)
-                    .style("left", (event.pageX + 5) + "px")
-                    .style("top", (event.pageY - 28) + "px");
-            })
-            .on("mouseout", () => {
-                tooltip.transition().duration(500).style("opacity", 0);
-            });
-
-        // Clip-path for text
-        leaf.append("clipPath")
-            .attr("id", d => `clip-${d.data.ticker}`)
-            .append("rect")
-            .attr("width", d => d.x1 - d.x0)
-            .attr("height", d => d.y1 - d.y0);
-
-        // Stock Labels (Ticker and Performance)
-        leaf.append("text")
-            .attr("class", "stock-label")
-            .attr("clip-path", d => `url(#clip-${d.data.ticker})`)
-            .selectAll("tspan")
-            .data(d => [d.data.ticker, `${d.data.performance.toFixed(2)}%`])
-            .join("tspan")
-            .attr("x", 4)
-            .attr("y", (d, i) => i === 0 ? "1.1em" : "2.2em")
-            .text(d => d);
-
-        heatmapWrapper.appendChild(svg.node());
-        container.appendChild(heatmapWrapper);
+        table.appendChild(tbody);
+        card.appendChild(table);
+        container.appendChild(card);
     }
 
+    function renderColumn(container, columnData) {
+        if (!container) return;
+        container.innerHTML = '';
+        const report = columnData ? columnData.weekly_report : null;
 
-    function renderAllHeatmaps(container, sp500Data, nasdaqData) {
-        if (sp500Data) {
-            renderHeatmap(container, 'S&P 500 Heatmap', sp500Data);
+        if (!report || !report.content) {
+            container.innerHTML = '<div class="card"><p>今週のAIコラムはまだありません。（毎週月曜日に生成されます）</p></div>';
+            return;
         }
-        if (nasdaqData) {
-            renderHeatmap(container, 'NASDAQ 100 Heatmap', nasdaqData);
-        }
+
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `
+            <div class="column-container">
+                <h3>${report.title || '週次AIコラム'}</h3>
+                <p class="column-date">Date: ${report.date || ''}</p>
+                <div class="column-content">
+                    ${report.content.replace(/\n/g, '<br>')}
+                </div>
+            </div>
+        `;
+        container.appendChild(card);
     }
 
-    async function fetchData() {
+    async function fetchDataAndRender() {
         try {
             const response = await fetch('/api/data');
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
             const data = await response.json();
             console.log("Data fetched successfully:", data);
 
-            dashboardElement.innerHTML = ''; // Clear loading message
-
-            // News Section
-            if (data.news) {
-                renderNews(dashboardElement, data.news);
+            const lastUpdatedEl = document.getElementById('last-updated');
+            if (data.last_updated) {
+                lastUpdatedEl.textContent = `Last updated: ${new Date(data.last_updated).toLocaleString('ja-JP')}`;
             }
 
-            // Heatmaps Section
-            const heatmapsContainer = document.createElement('div');
-            heatmapsContainer.className = 'heatmaps-main-container';
-
-            // Use the fetched data directly
-            let sp500HeatmapData = data.sp500_heatmap;
-            let nasdaqHeatmapData = data.nasdaq_heatmap;
-            
-            renderAllHeatmaps(heatmapsContainer, sp500HeatmapData, nasdaqHeatmapData);
-            dashboardElement.appendChild(heatmapsContainer);
+            renderMarketOverview(document.getElementById('market-content'), data.market);
+            renderNews(document.getElementById('news-content'), data.news);
+            renderHeatmap(document.getElementById('nasdaq-content'), 'NASDAQ 100 Heatmap', data.nasdaq_heatmap);
+            renderHeatmap(document.getElementById('sp500-content'), 'S&P 500 Heatmap', data.sp500_heatmap);
+            renderIndicators(document.getElementById('indicators-content'), data.indicators);
+            renderColumn(document.getElementById('column-content'), data.column);
 
         } catch (error) {
             console.error("Failed to fetch data:", error);
-            dashboardElement.innerHTML = `<p>Error loading data: ${error.message}</p>`;
+            document.getElementById('dashboard-content').innerHTML = `<div class="card"><p>データの読み込みに失敗しました: ${error.message}</p></div>`;
         }
     }
 
-    fetchData();
+    initTabs();
+    fetchDataAndRender();
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,16 +11,38 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 </head>
 <body>
-    <h1>HanaView Market Dashboard</h1>
-    <div id="dashboard">
-        <!-- Content will be loaded here by app.js -->
-        <div class="loading-container">
-            <p>Loading market data...</p>
-            <div class="loading-spinner"></div>
+    <div class="container">
+        <header class="header">
+            <h1>HanaView Market Dashboard</h1>
+            <p class="last-updated" id="last-updated">Last updated: --</p>
+        </header>
+
+        <div class="tab-container">
+            <button class="tab-button active" data-tab="market">市況</button>
+            <button class="tab-button" data-tab="news">ニュース</button>
+            <button class="tab-button" data-tab="nasdaq">NASDAQ 100</button>
+            <button class="tab-button" data-tab="sp500">S&P 500</button>
+            <button class="tab-button" data-tab="indicators">指標</button>
+            <button class="tab-button" data-tab="column">コラム</button>
         </div>
+
+        <main id="dashboard-content">
+            <div id="market-content" class="tab-pane active">
+                <div class="loading-container">
+                    <p>Loading market data...</p>
+                    <div class="loading-spinner"></div>
+                </div>
+            </div>
+            <div id="news-content" class="tab-pane"></div>
+            <div id="nasdaq-content" class="tab-pane"></div>
+            <div id="sp500-content" class="tab-pane"></div>
+            <div id="indicators-content" class="tab-pane"></div>
+            <div id="column-content" class="tab-pane"></div>
+        </main>
     </div>
     <script src="https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script type="text/javascript" src="https://s3.tradingview.com/tv.js"></script>
     <script src="app.js"></script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,14 +1,13 @@
 :root {
-    --background: #1a1a1a;
-    --card-background: #2a2a2a;
-    --tab-text: #00c853;
-    --tab-active-bg: #00c853;
+    --background: #E6F3F7;
+    --card-background: #FFFFFF;
+    --tab-text: #006B6B;
+    --tab-active-bg: #006B6B;
     --tab-active-text: #000000;
-    --text-primary: #e0e0e0;
-    --text-secondary: #b0b0b0;
-    --border-color: #3a3a3a;
-    --sector-bg: #1e1e1e;
-    --sector-border: #444;
+    --text-primary: #212121;
+    --text-secondary: #757575;
+    --border-color: #e0e0e0;
+    --shadow-color: rgba(0, 0, 0, 0.05);
 }
 
 body {
@@ -16,32 +15,112 @@ body {
     background-color: var(--background);
     color: var(--text-primary);
     margin: 0;
-    padding: 10px;
+    padding: 0;
     font-size: 14px;
+    line-height: 1.6;
 }
 
-h1 {
-    color: var(--tab-text);
-    text-align: center;
-    font-size: 1.5em;
-    margin: 20px 0;
-}
-
-#dashboard {
+.container {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 10px;
+    padding: 15px;
 }
 
-/* --- D3 Heatmap Styles --- */
-.heatmaps-main-container {
-    margin-top: 20px;
-    padding: 10px;
+.header {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.header h1 {
+    color: var(--tab-text);
+    font-size: 1.8em;
+    margin: 0 0 5px 0;
+}
+
+.last-updated {
+    color: var(--text-secondary);
+    font-size: 0.9em;
+    margin: 0;
+}
+
+/* --- Tab Styles --- */
+.tab-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    border-bottom: 2px solid var(--border-color);
+    margin-bottom: 20px;
+}
+
+.tab-button {
+    padding: 10px 20px;
+    cursor: pointer;
+    border: none;
+    background-color: transparent;
+    color: var(--tab-text);
+    font-size: 1em;
+    font-weight: 500;
+    border-bottom: 3px solid transparent;
+    transition: all 0.3s ease;
+    margin: 0 5px;
+}
+
+.tab-button:hover {
+    background-color: rgba(0, 107, 107, 0.05);
+}
+
+.tab-button.active {
+    color: var(--tab-active-text);
+    background-color: var(--tab-active-bg);
+    border-bottom-color: var(--tab-active-bg);
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+}
+
+.tab-pane {
+    display: none;
+    animation: fadeIn 0.5s;
+}
+
+.tab-pane.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* --- Card Style --- */
+.card {
     background-color: var(--card-background);
     border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    padding: 20px;
+    margin-bottom: 20px;
+    box-shadow: 0 4px 12px var(--shadow-color);
 }
 
+/* --- Loading Spinner --- */
+.loading-container {
+    text-align: center;
+    padding: 50px;
+    color: var(--text-secondary);
+}
+.loading-spinner {
+    margin: 20px auto;
+    border: 4px solid rgba(0,0,0,0.1);
+    border-left-color: var(--tab-text);
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: spin 1s linear infinite;
+}
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+
+/* --- D3 Heatmap Styles --- */
 .heatmap-wrapper {
     margin-bottom: 30px;
 }
@@ -50,34 +129,33 @@ h1 {
     color: var(--tab-text);
     font-size: 1.4em;
     text-align: left;
-    margin: 10px 0 15px 0;
+    margin-bottom: 15px;
     padding-bottom: 5px;
     border-bottom: 2px solid var(--border-color);
 }
 
-/* D3 SVG Styles */
 .sector-label {
-    fill: #fff;
-    font-size: 18px;
+    fill: #333;
+    font-size: 16px;
     font-weight: 600;
 }
 
 .industry-label {
-    fill: #ccc;
-    font-size: 14px;
+    fill: #666;
+    font-size: 13px;
     font-weight: 500;
 }
 
 .stock-rect {
-    stroke: #1a1a1a;
-    stroke-width: 1px;
+    stroke: var(--card-background);
+    stroke-width: 2px;
 }
 
 .stock-label {
     fill: white;
     font-size: 12px;
     font-weight: bold;
-    pointer-events: none; /* Allows mouse events to pass through to the rect */
+    pointer-events: none;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.7);
 }
 
@@ -86,12 +164,12 @@ h1 {
     text-align: left;
     padding: 8px;
     font-size: 12px;
-    background: #222;
-    border: 1px solid #555;
+    background: #fff;
+    border: 1px solid var(--border-color);
     border-radius: 4px;
     pointer-events: none;
-    color: #fff;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.5);
+    color: var(--text-primary);
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
     line-height: 1.4;
 }
 
@@ -103,25 +181,17 @@ h1 {
 }
 
 
-/* News Styles */
-.news-container {
-    padding: 10px;
-    margin-bottom: 20px;
-}
-
+/* --- News Styles --- */
 .news-summary {
-    background-color: var(--card-background);
-    color: var(--text-primary);
-    padding: 15px;
-    border-radius: 8px;
     margin-bottom: 20px;
-    border: 1px solid var(--border-color);
 }
 
 .news-summary h3, .main-topics-container h3 {
     margin-top: 0;
     color: var(--tab-text);
-    font-size: 1.1em;
+    font-size: 1.2em;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 5px;
 }
 
 .main-topics-container {
@@ -129,76 +199,194 @@ h1 {
 }
 
 .topic-box {
-    background-color: var(--sector-bg);
+    background-color: var(--background);
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    padding: 12px;
-    margin-bottom: 12px;
+    padding: 15px;
+    margin-bottom: 15px;
 }
 
 .topic-title {
     font-weight: bold;
-    margin-top: 0;
-    margin-bottom: 8px;
+    margin: 0 0 8px 0;
+    font-size: 1em;
+}
+
+.topic-title-red { color: #c62828; }
+.topic-title-blue { color: #1565c0; }
+
+.topic-box p {
+    margin: 0;
     font-size: 0.95em;
 }
 
-.topic-title-red {
-    color: #ef5350;
+/* --- Market Tab Styles --- */
+.market-section {
+    margin-bottom: 30px;
+}
+.market-section h3 {
+    color: var(--tab-text);
+    font-size: 1.3em;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 8px;
+    margin-bottom: 15px;
+}
+.market-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+}
+.fg-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 30px;
+}
+.fg-gauge {
+    position: relative;
+    width: 250px;
+    height: 125px;
+    overflow: hidden;
+}
+.fg-gauge-base {
+    width: 100%;
+    height: 100%;
+    border-radius: 250px 250px 0 0;
+    background: conic-gradient(
+        from -90deg,
+        #d32f2f 0%, #ef5350 20%, /* Extreme Fear */
+        #ffc107 40%,             /* Fear */
+        #fff176 50%,             /* Neutral */
+        #a5d6a7 60%,             /* Greed */
+        #4caf50 80%, #2e7d32 100% /* Extreme Greed */
+    );
+    -webkit-mask-image: radial-gradient(circle at 50% 100%, transparent 65%, black 66%);
+    mask-image: radial-gradient(circle at 50% 100%, transparent 65%, black 66%);
+}
+.fg-gauge-needle {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    width: 2px;
+    height: 110px;
+    background-color: #333;
+    transform-origin: bottom center;
+    transition: transform 0.8s ease-out;
+    box-shadow: 0 0 5px rgba(0,0,0,0.3);
+}
+.fg-gauge-center {
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 20px;
+    height: 20px;
+    background-color: #333;
+    border-radius: 50%;
+    border: 3px solid var(--card-background);
+}
+.fg-value-display {
+    text-align: center;
+}
+.fg-now-value {
+    font-size: 3em;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+.fg-now-category {
+    font-size: 1.2em;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+.fg-history {
+    text-align: center;
+    margin-top: 15px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+.fg-history p {
+    margin: 4px 0;
 }
 
-.topic-title-blue {
-    color: #42a5f5;
+/* --- Indicators Tab Styles --- */
+.indicators-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95em;
+}
+.indicators-table th, .indicators-table td {
+    padding: 10px 12px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+}
+.indicators-table thead th {
+    background-color: var(--background);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+.indicators-table tbody tr:nth-child(even) {
+    background-color: #f7f9fa;
+}
+.indicators-table tbody tr:hover {
+    background-color: #eff3f5;
+}
+.indicators-table .importance-3 {
+    color: #ff9800;
+    font-weight: bold;
 }
 
-.topic-box p {
-    margin: 5px 0;
-    line-height: 1.4;
+/* --- Column Tab Styles --- */
+.column-container h3 {
+    color: var(--tab-text);
+    font-size: 1.3em;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 8px;
+    margin-bottom: 5px;
+}
+.column-date {
     font-size: 0.9em;
+    color: var(--text-secondary);
+    margin-bottom: 15px;
+}
+.column-content {
+    line-height: 1.7;
 }
 
-/* モバイル対応 */
+/* --- Mobile Responsive --- */
 @media (max-width: 768px) {
-    body {
+    .container {
         padding: 5px;
     }
-    
-    #dashboard {
-        padding: 0;
+    .tab-button {
+        padding: 8px 10px;
+        font-size: 0.9em;
+        margin: 0 2px 5px 2px;
     }
-    
-    .heatmap-main-title {
-        font-size: 1.2em;
+    .header h1 {
+        font-size: 1.5em;
     }
-
-    .sector-label {
-        font-size: 14px;
+    .card {
+        padding: 15px;
     }
-
-    .industry-label {
-        font-size: 11px;
-    }
-
-    .stock-label {
-        font-size: 9px;
-    }
+    .heatmap-main-title { font-size: 1.2em; }
+    .sector-label { font-size: 14px; }
+    .industry-label { font-size: 11px; }
+    .stock-label { font-size: 9px; }
 }
 
-/* スクロールバーのスタイリング */
+/* --- Scrollbar --- */
 ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
 }
-
 ::-webkit-scrollbar-track {
     background: var(--background);
 }
-
 ::-webkit-scrollbar-thumb {
-    background: var(--border-color);
+    background: #ccc;
     border-radius: 4px;
 }
-
 ::-webkit-scrollbar-thumb:hover {
-    background: var(--text-secondary);
+    background: #aaa;
 }


### PR DESCRIPTION
設計書に基づき、フロントエンドのUIを全面的に改修し、複数の新機能を実装。また、バックエンドのAPIの挙動を改善した。

主な変更点:
- **タブUIの実装**: 主要機能（市況、ニュース、ヒートマップ、指標、コラム）を切り替えるための、完全なタブベースのナビゲーションを実装。
- **「市況」タブの実装**:
    - CNNのデザインを再現したFear & Greed IndexメーターをCSSで作成。
    - VIX指数と米国10年債のチャートをTradingViewウィジェットで埋め込み。
    - AIによる市況解説を表示。
- **新規コンテンツタブの実装**:
    - 「指標」タブに経済指標カレンダーをテーブル形式で表示。
    - 「コラム」タブに週次AIコラムを表示。
- **UIテーマの変更**: アプリケーション全体を、設計書で指定された水色ベースのライトテーマに変更。
- **バックエンドAPIの改善**: `/api/data`エンドポイントが、日付に基づいた最新のデータファイルを動的に返すよう修正し、日々の更新に対する堅牢性を向上。