### PR TITLE
feat: PWA機能の修正とデプロイ手順の追加

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,5 +43,18 @@
     <script src="https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="app.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('sw.js')
+                    .then(registration => {
+                        console.log('Service Worker registered with scope:', registration.scope);
+                    })
+                    .catch(error => {
+                        console.error('Service Worker registration failed:', error);
+                    });
+            });
+        }
+    </script>
 </body>
 </html>

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -2,18 +2,18 @@
   "name": "HanaView Market Dashboard",
   "short_name": "HanaView",
   "description": "A dashboard to efficiently check US market data.",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#E6F3F7",
   "theme_color": "#006B6B",
   "icons": [
     {
-      "src": "icons/icon-192x192.png",
+      "src": "./icons/icon-192x192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "icons/icon-512x512.png",
+      "src": "./icons/icon-512x512.png",
       "type": "image/png",
       "sizes": "512x512"
     }

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -1,12 +1,12 @@
 const CACHE_NAME = 'hanaview-cache-v1';
 const APP_SHELL_URLS = [
-  '/',
-  '/index.html',
-  '/style.css',
-  '/app.js',
-  '/manifest.json',
-  '/icons/icon-192x192.png',
-  '/icons/icon-512x512.png',
+  './',
+  './index.html',
+  './style.css',
+  './app.js',
+  './manifest.json',
+  './icons/icon-192x192.png',
+  './icons/icon-512x512.png',
   'https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js',
   'https://d3js.org/d3.v7.min.js'
 ];

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,13 +3,13 @@ events {}
 http {
     server {
         listen 80;
-        server_name localhost;
+        server_name example.com www.example.com;
         return 301 https://$host$request_uri;
     }
 
     server {
         listen 443 ssl;
-        server_name localhost;
+        server_name example.com www.example.com;
 
         ssl_certificate /etc/nginx/certs/nginx.crt;
         ssl_certificate_key /etc/nginx/certs/nginx.key;


### PR DESCRIPTION
PWAとして正しく機能するように、以下の点を修正しました。
- `frontend/index.html`: Service Workerを登録するスクリプトを追加。
- `frontend/sw.js`: キャッシュ対象URLを相対パスに修正。
- `frontend/manifest.json`: `start_url`とアイコンのパスを相対パスに修正。

また、Xserver VPSにDockerとCloudflareを利用してデプロイする手順を`README.md`に追記しました。
- `nginx/nginx.conf`: デプロイ手順に合わせて、`server_name`をサンプルドメインに変更。