### PR TITLE
Fix Docker build failure caused by incorrect cron setup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN chmod +x /app/backend/cron_job_*.sh
 # Add cron job
 COPY backend/cron_jobs /etc/cron.d/hanaview-cron
 RUN chmod 0644 /etc/cron.d/hanaview-cron
-RUN crontab /etc/cron.d/hanaview-cron
 
 # Start services.
 CMD cron && cd /app/backend && uvicorn main:app --host 0.0.0.0 --port 8000

--- a/backend/cron_jobs
+++ b/backend/cron_jobs
@@ -1,5 +1,4 @@
 # Data fetch (Mon-Sat 6:30 JST)
-30 6 * * 1-6 /app/backend/cron_job_fetch.sh
-
+30 6 * * 1-6 root /app/backend/cron_job_fetch.sh
 # Report generation (Mon-Sat 7:00 JST)
-0 7 * * 1-6 /app/backend/cron_job_generate.sh
+0 7 * * 1-6 root /app/backend/cron_job_generate.sh


### PR DESCRIPTION
The Docker build was failing due to an error when installing the crontab. This was caused by two issues:
1. The `crontab` command was being used to install a system-wide cron file, which is incorrect. Files in `/etc/cron.d/` are loaded automatically.
2. The cron file `backend/cron_jobs` was missing the required `user` field for system-wide cron jobs.

This commit resolves the build error by:
- Removing the `RUN crontab` command from the Dockerfile.
- Adding the `root` user to the cron job definitions in `backend/cron_jobs`.