### PR TITLE
Fix: Correct httpx.Client instantiation

### DIFF
--- a/backend/data_fetcher.py
+++ b/backend/data_fetcher.py
@@ -94,7 +94,9 @@ class MarketDataFetcher:
             logger.warning(f"[E001] {ERROR_CODES['E001']} AI functions will be skipped.")
             self.openai_client = None
         else:
-            http_client = httpx.Client(proxies={})
+            # trust_env=False to prevent httpx from using system proxy settings,
+            # which seems to be the original intent of proxies={}.
+            http_client = httpx.Client(trust_env=False)
             self.openai_client = openai.OpenAI(api_key=api_key, http_client=http_client)
 
     # --- Ticker List Fetching ---


### PR DESCRIPTION
The `proxies` keyword argument is no longer supported in the `httpx.Client` constructor. The original intent of `proxies={}` was likely to disable the use of proxy settings from the environment.

This commit replaces the deprecated `proxies={}` argument with `trust_env=False`, which is the correct and modern way to achieve this in the `httpx` library. This resolves the `TypeError` on startup.