### PR TITLE
Fix: Update ChromeDriver download method in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,21 @@ WORKDIR /app
 
 # Install system dependencies including Chrome and ChromeDriver.
 RUN apt-get update && apt-get install -y \
-    cron curl wget gnupg unzip && \
+    cron curl wget gnupg unzip jq && \
     # Add Chrome repository
     wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
     apt-get update && \
     # Install Chrome
     apt-get install -y google-chrome-stable && \
-    # Install ChromeDriver
-    CHROME_VERSION=$(google-chrome --version | awk '{print $3}' | awk -F. '{print $1}') && \
-    wget -q -O /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}/chromedriver_linux64.zip && \
-    unzip /tmp/chromedriver.zip -d /usr/local/bin/ && \
-    rm /tmp/chromedriver.zip && \
+    # Install ChromeDriver using the new JSON endpoints
+    CHROMEDRIVER_URL=$(curl -s https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -r '.channels.Stable.downloads.chromedriver[] | select(.platform=="linux64").url') && \
+    wget -q -O /tmp/chromedriver.zip ${CHROMEDRIVER_URL} && \
+    unzip /tmp/chromedriver.zip -d /tmp/ && \
+    mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver && \
     chmod +x /usr/local/bin/chromedriver && \
+    rm /tmp/chromedriver.zip && \
+    rm -rf /tmp/chromedriver-linux64 && \
     # Cleanup
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The previous method of downloading ChromeDriver from chromedriver.storage.googleapis.com is deprecated.

This commit updates the Dockerfile to use the new Chrome for Testing (CfT) JSON endpoints. It now fetches the URL for the latest stable version of ChromeDriver for linux64, downloads it, and installs it.

This change also adds `jq` as a dependency to parse the JSON response from the CfT endpoint.