### PR TITLE
Feat: Replace news scraping with yfinance and update UI

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -167,21 +167,44 @@ document.addEventListener('DOMContentLoaded', () => {
             container.innerHTML = '<div class="card"><p>ニュースデータがありません。</p></div>';
             return;
         }
+
         const card = document.createElement('div');
         card.className = 'card';
+
+        // Render summary
         if (newsData.summary) {
             card.innerHTML += `<div class="news-summary"><h3>今朝の3行サマリー</h3><p>${newsData.summary.replace(/\n/g, '<br>')}</p></div>`;
         }
+
+        // Render topics
         if (newsData.topics && newsData.topics.length > 0) {
             const topicsContainer = document.createElement('div');
             topicsContainer.className = 'main-topics-container';
             topicsContainer.innerHTML = '<h3>主要トピック</h3>';
+
             newsData.topics.forEach((topic, index) => {
-                topicsContainer.innerHTML += `
-                    <div class="topic-box">
-                        <p class="topic-title ${index === 0 ? 'topic-title-red' : 'topic-title-blue'}">${index + 1}. ${topic.title}</p>
-                        <p>${topic.body}</p>
-                    </div>`;
+                const topicBox = document.createElement('div');
+                topicBox.className = 'topic-box';
+
+                let topicContent = `
+                    <p class="topic-title ${index === 0 ? 'topic-title-red' : 'topic-title-blue'}">${index + 1}. ${topic.title}</p>
+                    <div class="topic-details">
+                        <div class="topic-section">
+                            <h4>事実</h4>
+                            <p>${topic.fact || 'N/A'}</p>
+                        </div>
+                        <div class="topic-section">
+                            <h4>解釈</h4>
+                            <p>${topic.interpretation || 'N/A'}</p>
+                        </div>
+                        <div class="topic-section">
+                            <h4>市場への影響</h4>
+                            <p>${topic.impact || 'N/A'}</p>
+                        </div>
+                    </div>
+                `;
+                topicBox.innerHTML = topicContent;
+                topicsContainer.appendChild(topicBox);
             });
             card.appendChild(topicsContainer);
         }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -302,6 +302,34 @@ body {
     font-size: 0.95em;
 }
 
+.topic-details {
+    margin-top: 15px;
+    padding-left: 10px;
+    border-left: 3px solid var(--border-color);
+}
+
+.topic-section {
+    margin-bottom: 12px;
+}
+
+.topic-section:last-child {
+    margin-bottom: 0;
+}
+
+.topic-section h4 {
+    margin: 0 0 4px 0;
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.topic-section p {
+    margin: 0;
+    padding-left: 10px;
+}
+
 /* --- Market Tab Styles --- */
 .market-section {
     margin-bottom: 30px;


### PR DESCRIPTION
- Replaced the previous news scraping mechanism with a more reliable method using the `yfinance` library to fetch news for major stock indices (NASDAQ, S&P 500, Dow 30, Nikkei 225).
- Updated the AI prompt in `data_fetcher.py` to process the new data format and generate structured news analysis with "fact," "interpretation," and "market impact" fields.
- Modified the `renderNews` function in `frontend/app.js` and added styles to `frontend/style.css` to display the new, more detailed news structure in the "News" tab. This provides users with deeper insights into major market-moving topics.