### PR TITLE
fix(frontend): Update Lightweight Charts API call

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
             },
         });
 
-        const candlestickSeries = chart.addCandlestickSeries({
+        const candlestickSeries = chart.addSeries(LightweightCharts.CandlestickSeries, {
             upColor: '#26a69a',
             downColor: '#ef5350',
             borderDownColor: '#ef5350',


### PR DESCRIPTION
The method `addCandlestickSeries` was removed in a recent version of the Lightweight Charts library. This commit updates the call to the new API `addSeries(LightweightCharts.CandlestickSeries, ...)` to fix the error 'chart.addCandlestickSeries is not a function'.