### PR TITLE
Refactor the display of economic indicator importance.

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -340,7 +340,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (typeof ind.importance === 'string') {
                 starCount = (ind.importance.match(/★/g) || []).length;
             }
-            const importanceStars = '★'.repeat(starCount).padEnd(3, '☆');
+        const importanceStars = '★'.repeat(starCount);
 
             // Split datetime into date and time
             const [date, time] = (ind.datetime || ' / ').split(' ');


### PR DESCRIPTION
The previous implementation used placeholder '☆' characters to pad the importance rating to a fixed width of three characters (e.g., "★★☆").

This change removes the padding, so that only the solid '★' stars representing the actual importance level are displayed, as requested by the user.